### PR TITLE
feat: add TOML-based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# README
+# YT-DLP Helper
+
+Simple interactive wrapper around [yt-dlp](https://github.com/yt-dlp/yt-dlp) for quick audio or video downloads.
+
+## Configuration
+
+Runtime options can be preconfigured via a `config.toml` file in the project directory.
+
+```toml
+[paths]
+# Where to store downloaded media
+video = "downloads/videos"
+audio = "downloads/audio"
+
+[defaults]
+# Choose default media type and codecs
+media_type = "video"
+video_codec = "mp4"
+audio_codec = "mp3"
+# Optional custom output template
+output_template = "%(title)s.%(ext)s"
+```
+
+Any missing value will trigger an interactive prompt when running `main.py`.
+
+## Usage
+
+Run the downloader:
+
+```bash
+python main.py
+```

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,18 @@
+# Sample configuration for the yt-dlp helper
+# Customize download paths and default codecs.
+
+[paths]
+# Where to save downloaded videos
+video = "downloads/videos"
+# Where to save downloaded audio files
+audio = "downloads/audio"
+
+[defaults]
+# Default media type: "video" or "audio"
+media_type = "video"
+# Preferred video codec when downloading videos
+video_codec = "mp4"
+# Preferred audio codec when downloading audio
+audio_codec = "mp3"
+# Optional yt-dlp output template
+output_template = "%(title)s.%(ext)s"

--- a/main.py
+++ b/main.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 """Simple command-line interface for downloading media with yt-dlp."""
 
+from __future__ import annotations
+
 import subprocess
 import sys
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+
+def load_config(path: str = "config.toml") -> dict:
+    """Return configuration values loaded from *path*.
+
+    Missing files result in an empty configuration.
+    """
+
+    try:
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except FileNotFoundError:
+        return {}
 
 
 def main() -> None:
@@ -10,7 +31,11 @@ def main() -> None:
     print("========== YT-DLP Helper ==========")
     print("Download audio or video from supported sites using yt-dlp.\n")
 
-    media_type = input("Select media type (video/audio): ").strip().lower()
+    cfg = load_config()
+
+    media_type = cfg.get("defaults", {}).get("media_type", "").lower()
+    if media_type not in {"video", "audio"}:
+        media_type = input("Select media type (video/audio): ").strip().lower()
     if media_type not in {"video", "audio"}:
         print("Invalid media type. Please choose 'video' or 'audio'.")
         sys.exit(1)
@@ -18,14 +43,20 @@ def main() -> None:
     if media_type == "video":
         codecs = {"mp4": "mp4", "webm": "webm"}
         print("Available video codecs:")
+        default_codec = cfg.get("defaults", {}).get("video_codec", "").lower()
+        download_path = cfg.get("paths", {}).get("video")
     else:
         codecs = {"mp3": "mp3", "m4a": "m4a", "flac": "flac"}
         print("Available audio codecs:")
+        default_codec = cfg.get("defaults", {}).get("audio_codec", "").lower()
+        download_path = cfg.get("paths", {}).get("audio")
 
     for name in codecs:
         print(f"- {name}")
 
-    codec = input("Choose codec: ").strip().lower()
+    codec = default_codec
+    if codec not in codecs:
+        codec = input("Choose codec: ").strip().lower()
     if codec not in codecs:
         print("Invalid codec selected.")
         sys.exit(1)
@@ -35,12 +66,20 @@ def main() -> None:
         print("No URL provided.")
         sys.exit(1)
 
+    cmd = ["yt-dlp"]
+    if download_path:
+        cmd.extend(["-P", Path(download_path).expanduser().as_posix()])
+
+    output_template = cfg.get("defaults", {}).get("output_template")
+    if output_template:
+        cmd.extend(["-o", output_template])
+
     try:
         if media_type == "video":
             fmt = f"bestvideo[ext={codecs[codec]}]+bestaudio/best"
-            cmd = ["yt-dlp", "-f", fmt, url]
+            cmd.extend(["-f", fmt, url])
         else:
-            cmd = ["yt-dlp", "-x", "--audio-format", codecs[codec], url]
+            cmd.extend(["-x", "--audio-format", codecs[codec], url])
 
         print("Running:", " ".join(cmd))
         subprocess.run(cmd, check=True)


### PR DESCRIPTION
## Summary
- add sample `config.toml` with paths, default codecs, and optional template
- load configuration in `main.py` using `tomllib`/`tomli`
- document configuration options in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689c2d4ae7a48321a82b08ed43ea11c1