### PR TITLE
Add requirements and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Simple interactive wrapper around [yt-dlp](https://github.com/yt-dlp/yt-dlp) for quick audio or video downloads.
 
+## Installation
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Configuration
 
 Runtime options can be preconfigured via a `config.toml` file in the project directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+yt-dlp
+tomli; python_version < "3.11"


### PR DESCRIPTION
## Summary
- Add `requirements.txt` listing runtime dependencies
- Document installation step using `pip install -r requirements.txt`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689c2ef9ef7c8321b6f70fa9ded8d641