### PR TITLE
Add config example and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ output_template = "%(title)s.%(ext)s"
 ```
 
 Any missing value will trigger an interactive prompt when running `main.py`.
+Downloaded filenames are sanitized to remove characters invalid on common filesystems.
 
 ## Usage
 
@@ -37,4 +38,12 @@ Run the downloader:
 
 ```bash
 python main.py
+```
+
+## Testing
+
+Run the unit tests with [pytest](https://docs.pytest.org/):
+
+```bash
+pytest
 ```

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,18 @@
+# Example configuration for the yt-dlp helper
+# Copy this file to `config.toml` and adjust the values as needed.
+
+[paths]
+# Directory where downloaded video files will be stored
+video = "downloads/videos"
+# Directory where downloaded audio files will be stored
+audio = "downloads/audio"
+
+[defaults]
+# Default media type to download ("video" or "audio")
+media_type = "video"
+# Preferred codec when downloading videos
+video_codec = "mp4"
+# Preferred codec when downloading audio
+audio_codec = "mp3"
+# Optional yt-dlp output template. See yt-dlp documentation for placeholders.
+output_template = "%(title)s.%(ext)s"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 yt-dlp
 tomli; python_version < "3.11"
+pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import load_config, build_command, sanitize_filename
+
+
+def test_load_config(tmp_path):
+    cfg_content = """
+[paths]
+video = "videos"
+
+[defaults]
+media_type = "video"
+"""
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text(cfg_content)
+    cfg = load_config(str(cfg_file))
+    assert cfg["paths"]["video"] == "videos"
+    assert cfg["defaults"]["media_type"] == "video"
+
+
+def test_load_config_missing(tmp_path):
+    cfg = load_config(str(tmp_path / "missing.toml"))
+    assert cfg == {}
+
+
+def test_build_command_video():
+    cfg = {
+        "paths": {"video": "vids"},
+        "defaults": {"output_template": "%(title)s:?*.%(ext)s"},
+    }
+    url = "http://example.com/video"
+    cmd = build_command("video", "mp4", url, cfg)
+    assert cmd == [
+        "yt-dlp",
+        "--restrict-filenames",
+        "-P",
+        Path("vids").as_posix(),
+        "-o",
+        "%(title)s___.%(ext)s",
+        "-f",
+        "bestvideo[ext=mp4]+bestaudio/best",
+        url,
+    ]
+
+
+def test_build_command_audio():
+    cfg = {"paths": {"audio": "aud"}}
+    url = "http://example.com/audio"
+    cmd = build_command("audio", "mp3", url, cfg)
+    assert cmd == [
+        "yt-dlp",
+        "--restrict-filenames",
+        "-P",
+        Path("aud").as_posix(),
+        "-x",
+        "--audio-format",
+        "mp3",
+        url,
+    ]
+
+
+def test_sanitize_filename():
+    name = "bad:name?file*.mp3"
+    assert sanitize_filename(name) == "bad_name_file_.mp3"


### PR DESCRIPTION
## Summary
- add documented `config.example.toml` for easy configuration
- introduce `build_command` helper and unit tests for config loading and command assembly
- document test execution and include pytest dependency
- sanitize filenames using a helper and yt-dlp's restrict option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c2fe829ec83219cf1aae69fd177f2