### PR TITLE
Validate URLs before invoking yt-dlp

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 import re
+from urllib.parse import urlparse
 
 try:  # Python 3.11+
     import tomllib
@@ -37,6 +38,12 @@ def sanitize_filename(name: str) -> str:
     """
 
     return _INVALID_CHARS.sub("_", name).strip()
+
+
+def is_valid_url(url: str) -> bool:
+    """Return True if *url* contains a scheme and network location."""
+    parsed = urlparse(url)
+    return bool(parsed.scheme and parsed.netloc)
 
 
 def build_command(media_type: str, codec: str, url: str, cfg: dict | None = None) -> list[str]:
@@ -106,10 +113,13 @@ def main() -> None:
         print("Invalid codec selected.")
         sys.exit(1)
 
-    url = input("Enter video URL: ").strip()
-    if not url:
-        print("No URL provided.")
-        sys.exit(1)
+    while True:
+        url = input("Enter video URL: ").strip()
+        if is_valid_url(url):
+            break
+        print(
+            "Invalid URL. Please provide a valid URL including scheme (e.g., https://example.com)."
+        )
 
     try:
         cmd = build_command(media_type, codecs[codec], url, cfg)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import main
-from main import load_config, build_command, sanitize_filename
+from main import load_config, build_command, sanitize_filename, is_valid_url
 
 
 def test_load_config(tmp_path):
@@ -71,6 +71,12 @@ def test_sanitize_filename():
     assert sanitize_filename(name) == "bad_name_file_.mp3"
 
 
+def test_is_valid_url():
+    assert is_valid_url("https://example.com")
+    assert not is_valid_url("example.com")
+    assert not is_valid_url("http://")
+
+
 def test_main_uses_default_codec(monkeypatch):
     cfg = {"defaults": {"media_type": "audio", "audio_codec": "mp3"}}
     monkeypatch.setattr(main, "load_config", lambda: cfg)
@@ -96,3 +102,20 @@ def test_main_invalid_codec(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         main.main()
     assert exc.value.code == 1
+
+
+def test_main_reprompts_invalid_url(monkeypatch, capsys):
+    cfg = {"defaults": {"media_type": "audio", "audio_codec": "mp3"}}
+    monkeypatch.setattr(main, "load_config", lambda: cfg)
+    inputs = iter(["", "not a url", "https://example.com"])
+    monkeypatch.setattr(builtins, "input", lambda _: next(inputs))
+    recorded = {}
+
+    def fake_run(cmd, check):
+        recorded["cmd"] = cmd
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    main.main()
+    assert recorded["cmd"][-1] == "https://example.com"
+    captured = capsys.readouterr()
+    assert "Invalid URL" in captured.out


### PR DESCRIPTION
## Summary
- add `is_valid_url` helper and loop to ensure user supplies URL with scheme and domain
- show friendly error when URL is invalid
- cover URL validation with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c37a587f48321894c469b4b6eb49f